### PR TITLE
fix(foundry): drop the DEFAULT_ENDPOINT fallback left in `test` and `delete`

### DIFF
--- a/scripts/foundry_agent.py
+++ b/scripts/foundry_agent.py
@@ -100,7 +100,7 @@ def cmd_test(args: argparse.Namespace) -> None:
     from azure.ai.projects import AIProjectClient
     from azure.identity import DefaultAzureCredential
 
-    endpoint = _get_env("PROJECT_ENDPOINT", DEFAULT_ENDPOINT)
+    endpoint = _get_env("PROJECT_ENDPOINT")
     question = args.question or "Qual é a população atual do Brasil segundo o IBGE?"
 
     with (
@@ -152,7 +152,7 @@ def cmd_delete(args: argparse.Namespace) -> None:
     from azure.ai.projects import AIProjectClient
     from azure.identity import DefaultAzureCredential
 
-    endpoint = _get_env("PROJECT_ENDPOINT", DEFAULT_ENDPOINT)
+    endpoint = _get_env("PROJECT_ENDPOINT")
     name = args.name or AGENT_NAME
 
     with (


### PR DESCRIPTION
## Problem

`scripts/foundry_agent.py` has three subcommands — `create`, `test`, `delete`. Two of them crash immediately:

```console
$ export PROJECT_ENDPOINT="https://<res>.services.ai.azure.com/api/projects/<proj>"
$ python scripts/foundry_agent.py test
Traceback (most recent call last):
  File "scripts/foundry_agent.py", line 103, in cmd_test
    endpoint = _get_env("PROJECT_ENDPOINT", DEFAULT_ENDPOINT)
                                            ^^^^^^^^^^^^^^^^
NameError: name 'DEFAULT_ENDPOINT' is not defined
```

Same for `delete` (line 155). Setting `PROJECT_ENDPOINT` does not help — the default argument is evaluated before `_get_env()` ever looks at `os.environ`.

## Cause

0c55736 (*"chore(legal): add NOTICE, SOURCES.md, ACCEPTABLE_USE.md; rebrand to MCP Brasil"*) removed the hardcoded endpoint:

```diff
-DEFAULT_ENDPOINT = "https://agent-brasil-resource.services.ai.azure.com/api/projects/agent-brasil"
...
-    endpoint = _get_env("PROJECT_ENDPOINT", DEFAULT_ENDPOINT)
+    endpoint = _get_env("PROJECT_ENDPOINT")
```

but only inside `cmd_create()`. The two other call sites kept referring to the deleted name. `DEFAULT_MODEL`, right next to it, was kept, which is why this reads as correct at a glance.

```console
$ python3 -m pyflakes scripts/foundry_agent.py
scripts/foundry_agent.py:103:45: undefined name 'DEFAULT_ENDPOINT'
scripts/foundry_agent.py:155:45: undefined name 'DEFAULT_ENDPOINT'
```

## Fix

Apply to both sites exactly what 0c55736 applied to `cmd_create()`. There is no sensible project-wide default for an Azure AI Foundry endpoint — it is per-tenant, and `docs/deploy/foundry-teams.md:200` already documents exporting `PROJECT_ENDPOINT` — so requiring it is the intended behaviour.

## Verification

Ran all three subcommands with the `azure.*` packages stubbed, so only the script itself can fail:

| subcommand | before | after |
|---|---|---|
| `create` | rc=0 (`Agent created: ...`) | rc=0, unchanged |
| `test` | `NameError: name 'DEFAULT_ENDPOINT' is not defined` | reaches the Azure client calls |
| `delete` | `NameError: name 'DEFAULT_ENDPOINT' is not defined` | reaches the Azure client calls |

And with `PROJECT_ENDPOINT` unset, both now produce the message `_get_env()` was written to give instead of a traceback:

```console
$ python scripts/foundry_agent.py test
Error: PROJECT_ENDPOINT is not set and has no default.
$ echo $?
1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
